### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
       id: setup
       with:
         dotnet-version: ${{env.dotnet-version}}
+        dotnet-quality: ga
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
@@ -46,7 +47,7 @@ jobs:
         path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: Publish (NuGet - nuget.org)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
 
   <!-- Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="MetaBrainz.MusicBrainz.DiscId" Version="5.0.0" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageVersion Include="MetaBrainz.MusicBrainz.DiscId" Version="4.0.0" />
+    <PackageVersion Include="MetaBrainz.MusicBrainz.DiscId" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-mbdiscid/dotnet-mbdiscid.csproj
+++ b/dotnet-mbdiscid/dotnet-mbdiscid.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.1" />
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="4.0.0" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>
     <Title>DiscID Utility</Title>
     <Description>Small tool to get a disc's discid, MCN, ISRC and/or CD-TEXT.</Description>
     <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
-    <PackageCopyrightYears>2016-2023</PackageCopyrightYears>
+    <PackageCopyrightYears>2016-2025</PackageCopyrightYears>
     <PackageId>MetaBrainz.MusicBrainz.$(AssemblyName)</PackageId>
     <PackageTags>MusicBrainz discid audio cd cd-text isrc upc ean libdiscid</PackageTags>
     <Version>3.0.1-pre</Version>

--- a/dotnet-mbdiscid/dotnet-mbdiscid.csproj
+++ b/dotnet-mbdiscid/dotnet-mbdiscid.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2016-2025</PackageCopyrightYears>
     <PackageId>MetaBrainz.MusicBrainz.$(AssemblyName)</PackageId>
     <PackageTags>MusicBrainz discid audio cd cd-text isrc upc ean libdiscid</PackageTags>
-    <Version>3.0.1-pre</Version>
+    <Version>4.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/dotnet-mbdiscid/dotnet-mbdiscid.csproj
+++ b/dotnet-mbdiscid/dotnet-mbdiscid.csproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="MetaBrainz.MusicBrainz.DiscId" />
   </ItemGroup>
 


### PR DESCRIPTION
Update `MetaBrainz.Build.Sdk` to version 4.0.0. This means we now target `net8.0` only.

This also tweaks the build, requesting GA .NET SDKs only (so no previews), and passing `--skip-duplicate` on the NuGet push, to make it easier to rerun the build for a tag if something goes wrong during publishing.

In addition, `MetaBrainz.MusicBrainz.DiscId` was updated to version 5.0.0, and the unused `JetBrains.Annotations` dependency was removed.